### PR TITLE
Refs #4: page du quiz – police 'Patrick Hand' + ajustements UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
     <title>my-quiz</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Bangers&family=Press+Start+2P&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Bangers&family=Press+Start+2P&family=Patrick+Hand&display=swap" rel="stylesheet">
     <link rel="preload" as="image" href="/images/Beach.jpeg" fetchpriority="high">
   </head>
   <body>

--- a/src/pages/Game.jsx
+++ b/src/pages/Game.jsx
@@ -253,8 +253,8 @@ const styles = {
     boxShadow: '0 0 0 4px rgba(255,59,48,0.5) inset, 0 8px 24px rgba(0,0,0,0.25)'
   },
   answerBadge: {
-    fontFamily: 'Press Start 2P, system-ui',
-    fontSize: '16px',
+    fontFamily: 'Patrick Hand, system-ui',
+    fontSize: '24px',
     color: '#1a1a1a',
     background: '#ffffff',
     border: '6px solid #2b64ff',
@@ -276,8 +276,10 @@ const styles = {
     borderColor: '#ff3b30',
   },
   answerLabel: {
-    fontFamily: 'Press Start 2P, system-ui',
-    fontSize: '16px',
+    fontFamily: 'Patrick Hand, system-ui',
+    fontSize: '28px',
+    letterSpacing: '0.5px',
+    textShadow: '0 2px 0 rgba(0,0,0,0.1)'
   },
   labelStrong: {
     fontWeight: 700,


### PR DESCRIPTION
Page du quiz – UI complète (desktop, sans API)
- Titre "QUIZ" centré
- Question en panneau blanc bordure bleue
- Réponses en ardoises 2×2 avec pastilles A/B/C/D
- Police "Patrick Hand" pour réponses et badges
- Sélection: bonne = vert, mauvaise choisie = rouge
- Compteur Question x/y (haut-droite)
- Encart Joueur + Score (haut-gauche)
- Bouton "Suivant" (active après sélection)
- Structure prête pour API: { question, choices, correctIndex }
